### PR TITLE
Revert "resolves #24"

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -20,4 +20,5 @@ exclude: [
 .git,
 .gitignore,
 README.md,
-.sass-cache]
+.sass-cache
+]

--- a/_plugins/myfilters.rb
+++ b/_plugins/myfilters.rb
@@ -1,9 +1,0 @@
-module Jekyll
-	module MyFilters
-		def file_date(input)
-			File.mtime(input)
-		end
-	end
-end
-
-Liquid::Template.register_filter(Jekyll::MyFilters)

--- a/_sass/partials/_general.scss
+++ b/_sass/partials/_general.scss
@@ -230,11 +230,3 @@ iframe{
 p + p{
     margin-top: 20px;
 }
-
-.modified{
-	text-align:center;
-}
-
-#foot_center{
-	text-align: center;
-}

--- a/index.html
+++ b/index.html
@@ -18,9 +18,7 @@ title: index
                     <h4>{{ entry.title }}</h4>
             {% endcase %}
 
-						{{ entry.content }}
-						<p class="modified">Section last modified  {{entry.path | file_date |date_to_string}}</p>
+            {{ entry.content }}
         </section>
     {% endif %}
-		{% endfor %}
-		<section id="foot_center">Page last modified	{{page.path | file_date |date_to_string}}</section>
+{% endfor %}


### PR DESCRIPTION
This reverts commit 345c255936f0fbcb7427b36901a0afb8f31285c5.

The dates on files were not generated accurately when hosted on GitHub's servers. I'll see if there's another way to do this.