### PR TITLE
Add blog posts link from current projects page

### DIFF
--- a/_site/projects-current.html
+++ b/_site/projects-current.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html lang="en"><head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1"><!-- Begin Jekyll SEO tag v2.7.1 -->
+<title>Current Projects | DLF Metadata Assessment Working Group</title>
+<meta name="generator" content="Jekyll v3.9.0" />
+<meta property="og:title" content="Current Projects" />
+<meta name="author" content="DLF AIG Metadata Working Group" />
+<meta property="og:locale" content="en_US" />
+<link rel="canonical" href="http://localhost:4000/projects-current" />
+<meta property="og:url" content="http://localhost:4000/projects-current" />
+<meta property="og:site_name" content="DLF Metadata Assessment Working Group" />
+<meta name="twitter:card" content="summary" />
+<meta property="twitter:title" content="Current Projects" />
+<script type="application/ld+json">
+{"@type":"WebPage","url":"http://localhost:4000/projects-current","author":{"@type":"Person","name":"DLF AIG Metadata Working Group"},"headline":"Current Projects","@context":"https://schema.org"}</script>
+<!-- End Jekyll SEO tag -->
+<link rel="stylesheet" href="/assets/main.css">
+</head>
+<body><header class="site-header" role="banner">
+
+  <div class="wrapper">
+	  <nav class="site-nav">
+		<input type="checkbox" id="nav-trigger" class="nav-trigger" />
+		<label for="nav-trigger">
+		  <span class="menu-icon">
+			<svg viewBox="0 0 18 15" width="18px" height="15px">
+			  <path d="M18,1.484c0,0.82-0.665,1.484-1.484,1.484H1.484C0.665,2.969,0,2.304,0,1.484l0,0C0,0.665,0.665,0,1.484,0 h15.032C17.335,0,18,0.665,18,1.484L18,1.484z M18,7.516C18,8.335,17.335,9,16.516,9H1.484C0.665,9,0,8.335,0,7.516l0,0 c0-0.82,0.665-1.484,1.484-1.484h15.032C17.335,6.031,18,6.696,18,7.516L18,7.516z M18,13.516C18,14.335,17.335,15,16.516,15H1.484 C0.665,15,0,14.335,0,13.516l0,0c0-0.82,0.665-1.483,1.484-1.483h15.032C17.335,12.031,18,12.695,18,13.516L18,13.516z"/>
+			</svg>
+		  </span>
+		</label>
+		<div>
+			<a href="/"><img class="header-logo" src="/img/dlf-aig.png"/></a>
+		</div>
+		<div class="trigger">
+			<a class="page-link" href="/about">About</a>
+			<a class="page-link" href="/projects">Projects</a>
+			<a class="page-link" href="/take-part">Take Part</a>
+			<a class="page-link" href="/contributors">Contributors</a>
+			<a class="page-link" href="/resources">Resources</a>
+		</div>
+	  </nav>
+  </div>
+</header>
+<main class="page-content" aria-label="Content">
+      <div class="wrapper">
+        <article class="post">
+
+  <header class="post-header">
+    <h1 class="post-title">Current Projects</h1>
+  </header>
+
+  <div class="post-content">
+    
+<p><a href="/projects">Projects</a>-&gt;Current Projects</p>
+
+<h1 id="top">Current Projects</h1>
+
+<ul>
+  <li><a href="/tools">A <b>repository</b> for metadata assessment tools (Ongoing/Current)</a>.</li>
+  <li><a href="https://dlfmetadataassessment.github.io/MetadataSpecsClearinghouse">A <b>collection</b> of metadata application profiles, mappings, and practices (Ongoing/Current)</a>.</li>
+  <li><a href="https://www.diglib.org/category/assessment/"><b>Blog posts</b> about metadata assessment</a>.</li>
+</ul>
+
+  </div>
+
+</article>
+
+      </div>
+    </main>
+
+
+
+  </body>
+
+</html>

--- a/entries/projects-current.md
+++ b/entries/projects-current.md
@@ -11,4 +11,4 @@ permalink: projects-current
 
 * [A <b>repository</b> for metadata assessment tools (Ongoing/Current)](/tools).
 * [A <b>collection</b> of metadata application profiles, mappings, and practices (Ongoing/Current)](https://dlfmetadataassessment.github.io/MetadataSpecsClearinghouse).
-* Blog posts (page to be created)
+* [<b>Blog posts</b> about metadata assessment](https://www.diglib.org/category/assessment/).


### PR DESCRIPTION
Fixes #109. @kateefly, is it correct that this commit should include both the updated Markdown and the generated HTML file under `/_site`, because the renamed `projects-current.html` page, referenced by `projects.html`, wasn't previously in the Git repository? Apologies for my uncertainty on this. I can fix or redo this over the weekend as needed.